### PR TITLE
feat:  add socket option to cache group metadata

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -100,5 +100,6 @@ export const DEFAULT_CACHE_TTLS = {
   SIGNAL_STORE: 5 * 60, // 5 minutes
   MSG_RETRY: 60 * 60, // 1 hour
   CALL_OFFER: 5 * 60, // 5 minutes
-  USER_DEVICES: 5 * 60 // 5 minutes
+  USER_DEVICES: 5 * 60, // 5 minutes
+  GROUP_METADATA: 15 * 60 // 15 minutes
 };

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -819,7 +819,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
           creds: authState.creds,
           keyStore: authState.keys,
           logger,
-          options: config.options
+          options: config.options,
+          config
         })
       ]);
     }

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -1,4 +1,6 @@
+import NodeCache from "node-cache";
 import { proto } from "../../WAProto";
+import { DEFAULT_CACHE_TTLS } from "../Defaults";
 import {
   GroupMetadata,
   ParticipantAction,
@@ -22,6 +24,13 @@ import {
 import { makeChatsSocket } from "./chats";
 
 export const makeGroupsSocket = (config: SocketConfig) => {
+  if (!config.groupMetadataCache) {
+    config.groupMetadataCache = new NodeCache({
+      stdTTL: DEFAULT_CACHE_TTLS.GROUP_METADATA,
+      useClones: false
+    });
+  }
+
   const sock = makeChatsSocket(config);
   const { authState, ev, query, upsertMessage } = sock;
 

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -217,8 +217,6 @@ export type AnyMessageContent =
 type MinimalRelayOptions = {
   /** override the message ID with a custom provided string */
   messageId?: string;
-  /** cached group metadata, use to prevent redundant requests to WA & speed up msg sending */
-  cachedGroupMetadata?: (jid: string) => Promise<GroupMetadata | undefined>;
 };
 
 export type MessageRelayOptions = MinimalRelayOptions & {

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -53,6 +53,8 @@ export type SocketConfig = {
   transactionOpts: TransactionCapabilityOptions;
   /** provide a cache to store a user's device list */
   userDevicesCache?: NodeCache;
+  /** provide a cache to store metadata, used to prevent redundant requests to WA & speed up msg sending */
+  groupMetadataCache?: NodeCache;
   /** marks the client as online whenever the socket successfully connects */
   markOnlineOnConnect: boolean;
   /**

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -8,6 +8,7 @@ import {
   GroupMetadata,
   ParticipantAction,
   SignalKeyStoreWithTransaction,
+  SocketConfig,
   WAMessageStubType
 } from "../Types";
 import {
@@ -24,6 +25,7 @@ type ProcessMessageContext = {
   ev: BaileysEventEmitter;
   logger?: Logger;
   options: AxiosRequestConfig<any>;
+  config: SocketConfig;
 };
 
 const MSG_MISSED_CALL_TYPES = new Set([
@@ -75,6 +77,47 @@ export const isRealMessage = (message: proto.IWebMessageInfo) => {
 export const shouldIncrementChatUnread = (message: proto.IWebMessageInfo) =>
   !message.key.fromMe && !message.messageStubType;
 
+const updateGroupMetadata = (
+  groupMetadata: GroupMetadata,
+  action: ParticipantAction,
+  participants: string[]
+): GroupMetadata => {
+  const findParticipant = (id: string) =>
+    groupMetadata.participants.find(p => areJidsSameUser(p.id, id));
+
+  switch (action) {
+    case "add":
+      participants.forEach(id => {
+        if (!findParticipant(id)) {
+          groupMetadata.participants.push({ id, admin: null });
+        }
+      });
+      break;
+
+    case "remove":
+      groupMetadata.participants = groupMetadata.participants.filter(
+        p => !participants.includes(p.id)
+      );
+      break;
+
+    case "promote":
+      participants.forEach(id => {
+        const p = findParticipant(id);
+        if (p) p.admin = "admin";
+      });
+      break;
+
+    case "demote":
+      participants.forEach(id => {
+        const p = findParticipant(id);
+        if (p) p.admin = null;
+      });
+      break;
+  }
+
+  return groupMetadata;
+};
+
 const processMessage = async (
   message: proto.IWebMessageInfo,
   {
@@ -83,7 +126,8 @@ const processMessage = async (
     creds,
     keyStore,
     logger,
-    options
+    options,
+    config
   }: ProcessMessageContext
 ) => {
   const meId = creds.me!.id;
@@ -239,10 +283,35 @@ const processMessage = async (
     const jid = message.key!.remoteJid!;
     //let actor = whatsappID (message.participant)
     let participants: string[];
-    const emitParticipantsUpdate = (action: ParticipantAction) =>
+
+    const emitParticipantsUpdate = (action: ParticipantAction) => {
       ev.emit("group-participants.update", { id: jid, participants, action });
+
+      const groupMetadata = config.groupMetadataCache?.get(jid) as
+        | GroupMetadata
+        | undefined;
+
+      if (!groupMetadata) return;
+
+      const updatedMetadata = updateGroupMetadata(
+        groupMetadata,
+        action,
+        participants
+      );
+
+      config.groupMetadataCache?.set(jid, updatedMetadata);
+    };
+
     const emitGroupUpdate = (update: Partial<GroupMetadata>) => {
       ev.emit("groups.update", [{ id: jid, ...update }]);
+
+      const groupMetadata = config.groupMetadataCache?.get(jid) as
+        | GroupMetadata
+        | undefined;
+
+      if (!groupMetadata) return;
+
+      config.groupMetadataCache?.set(jid, { ...groupMetadata, ...update });
     };
 
     const participantsIncludesMe = () =>


### PR DESCRIPTION
- Nova opção `groupMetadataCache` no socket config. Se omitida, um cache padrão de 15 minutos será usado.
- Adiciona cache aos metadados do grupo, evitando fazer uma query a cada envio de mensagem.
- Atualiza o cache em tempo real quando algum participante eh removido ou adicionado. 
