### PR TITLE
fix: group messages retry not working

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -394,8 +394,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
   ) => {
     const meId = authState.creds.me!.id;
     const meLid = authState.creds.me!.lid;
+    const isRetryResend = Boolean(participant?.jid);
 
-    let shouldIncludeDeviceIdentity = false;
+    let shouldIncludeDeviceIdentity = isRetryResend;
 
     const { user, server } = jidDecode(jid)!;
     const statusJid = "status@broadcast";
@@ -469,13 +470,6 @@ export const makeMessagesSocket = (config: SocketConfig) => {
             ? groupData.participants.map(p => p.id)
             : [];
 
-          if (!isStatus) {
-            additionalAttributes = {
-              ...additionalAttributes,
-              addressing_mode: groupData?.addressingMode || "pn"
-            };
-          }
-
           if (groupData?.ephemeralDuration) {
             additionalAttributes = {
               ...additionalAttributes,
@@ -495,6 +489,13 @@ export const makeMessagesSocket = (config: SocketConfig) => {
           devices.push(...additionalDevices);
         }
 
+        if (isGroup) {
+          additionalAttributes = {
+            ...additionalAttributes,
+            addressing_mode: groupData?.addressingMode || "pn"
+          };
+        }
+
         const { ciphertext, senderKeyDistributionMessageKey } =
           await encryptSenderKeyMsgSignalProto(
             destinationJid,
@@ -511,7 +512,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
             groupData?.addressingMode === "lid" ? "lid" : "s.whatsapp.net",
             device
           );
-          if (!senderKeyMap[jid] || !!participant) {
+          if (!senderKeyMap[jid] && !isRetryResend) {
             senderKeyJids.push(jid);
             // store that this person has had the sender keys sent to them
             senderKeyMap[jid] = true;
@@ -543,15 +544,30 @@ export const makeMessagesSocket = (config: SocketConfig) => {
           participants.push(...result.nodes);
         }
 
-        binaryNodeContent.push({
-          tag: "enc",
-          attrs: { v: "2", type: "skmsg" },
-          content: ciphertext
-        });
+        if (isRetryResend) {
+          const { type, ciphertext: encryptedContent } =
+            await encryptSignalProto(participant!.jid, encodedMsg, authState);
 
-        await authState.keys.set({
-          "sender-key-memory": { [jid]: senderKeyMap }
-        });
+          binaryNodeContent.push({
+            tag: "enc",
+            attrs: {
+              v: "2",
+              type,
+              count: participant!.count.toString()
+            },
+            content: encryptedContent
+          });
+        } else {
+          binaryNodeContent.push({
+            tag: "enc",
+            attrs: { v: "2", type: "skmsg" },
+            content: ciphertext
+          });
+
+          await authState.keys.set({
+            "sender-key-memory": { [jid]: senderKeyMap }
+          });
+        }
       } else {
         const { user: meUser } = jidDecode(meId)!;
         const { user: meLidUser } = jidDecode(meLid)!;


### PR DESCRIPTION
Ao enviar uma mensagem em um grupo, caso algum dos participantes do grupo não tem sessão válida para descriptografar a mensagem, um retry request é recebido e a mensagem deve ser reenviada. 

Porém, antes dessa PR, o conteúdo da mensagem estava incorreto (enviando `skmsg`, quando, na verdade, deveríamos enviar uma `pkmsg`.

Para testar:
PS: a função `getMessage` deve estar definida no socket, e ser capaz de recuperar a mensagem para reenviar.

- Conecte 2 números que façam parte do mesmo grupo (A e B).
- Envie mensagem do número A para o número B.
- Limpe as `sessions` e `sender-key` do número B.
- Envie uma nova mensagem do número A para o número B. 
 - Nesse momento, o número A deve receber um pedido de `retry`, para que reenvie a mensagem.
 - A mensagem deve ser reenviada e ser descriptografada corretamente no número B.
 - Antes dessa PR, a mensagem não era descriptografada. 
 
 
 English version:
 
 When sending a message in a group, if any of the group participants doesn't have a valid session to decrypt the message, a retry request is received and the message must be resent.

However, prior to this PR, the message content was incorrect (sending `skmsg` when, in fact, we should have sent a `pkmsg`).

To test:

- Connect two numbers that are part of the same group (A and B).
- Send a message from number A to number B.
- Clear the `sessions` and `sender-key` on number B.
- Send a new message from number A to number B.
- At this point, number A should receive a `retry` request, so it resends the message.
- The message should be resent and decrypted correctly on number B.
- Prior to this PR, the message was not decrypted.
 
 Thanks @[Santosl2](https://github.com/Santosl2)