### PR TITLE
feat: add new sent messages cache to allow retry resend

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -16,10 +16,8 @@ export const WA_DEFAULT_EPHEMERAL = 7 * 24 * 60 * 60;
 
 export const DEFAULT_CACHE_TTLS = {
   SIGNAL_STORE: 5 * 60, // 5 minutes
-  MSG_RETRY: 60 * 60, // 1 hour
-  CALL_OFFER: 5 * 60, // 5 minutes
-  USER_DEVICES: 5 * 60, // 5 minutes
-  GROUP_METADATA: 15 * 60 // 15 minutes
+  GROUP_METADATA: 15 * 60, // 15 minutes
+  SENT_MESSAGES: 20 // 20 seconds
 };
 
 export const NOISE_MODE = "Noise_XX_25519_AESGCM_SHA256\0\0\0\0";
@@ -68,6 +66,10 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
   getMessage: async () => undefined,
   groupMetadataCache: new NodeCache({
     stdTTL: DEFAULT_CACHE_TTLS.GROUP_METADATA,
+    useClones: false
+  }),
+  sentMessagesCache: new NodeCache({
+    stdTTL: DEFAULT_CACHE_TTLS.SENT_MESSAGES,
     useClones: false
   })
 };

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -52,7 +52,13 @@ import { makeMessagesSocket } from "./messages-send";
 import { randomBytes } from "crypto";
 
 export const makeMessagesRecvSocket = (config: SocketConfig) => {
-  const { logger, retryRequestDelayMs, getMessage, shouldIgnoreJid } = config;
+  const {
+    logger,
+    retryRequestDelayMs,
+    getMessage,
+    sentMessagesCache,
+    shouldIgnoreJid
+  } = config;
   const sock = makeMessagesSocket(config);
   const {
     ev,
@@ -540,7 +546,13 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
     ids: string[],
     retryNode: BinaryNode
   ) => {
-    const msgs = await Promise.all(ids.map(id => getMessage({ ...key, id })));
+    const msgs = await Promise.all(
+      ids.map(
+        id =>
+          (sentMessagesCache?.get(id) as proto.IMessage | undefined) ||
+          getMessage({ ...key, id })
+      )
+    );
     const remoteJid = key.remoteJid!;
     const participant = key.participant || remoteJid;
     // if it's the primary jid sending the request

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -848,6 +848,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
           messageId: fullMsg.key.id!,
           additionalAttributes
         });
+
+        config.sentMessagesCache?.set(fullMsg.key.id!, fullMsg.message);
+
         if (config.emitOwnEvents) {
           process.nextTick(() => {
             upsertMessage(fullMsg, "append");

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -53,8 +53,10 @@ export type SocketConfig = {
   transactionOpts: TransactionCapabilityOptions;
   /** provide a cache to store a user's device list */
   userDevicesCache?: NodeCache;
-  /** provide a cache to store metadata, used to prevent redundant requests to WA & speed up msg sending */
+  /** provide a cache to store metadata, used to prevent redundant requests to WA & speed up msg sending. Pass undefined to disable */
   groupMetadataCache?: NodeCache;
+  /** provide a cache to store recently sent messages, used to resend the message when someone fails to decrypt it (waiting for this message problem). Default cache store message per 20 seconds. Pass undefined to disable*/
+  sentMessagesCache?: NodeCache;
   /** marks the client as online whenever the socket successfully connects */
   markOnlineOnConnect: boolean;
   /**


### PR DESCRIPTION
Inspirado na PR https://github.com/canove/whaileys/pull/8 do @pvictorlv.

- Adiciona um cache padrão para guardar mensagens enviadas por 20 segundos.
- O cache pode ser desabilitado passando `sentMessagesCache: undefined` nas configurações.
- Possibilita o retry resend funcionar sem nenhuma store ou configuração por parte do usuário.

----
Inspired by PR https://github.com/canove/whaileys/pull/8 from @pvictorlv.

- Adds a default cache to save sent messages for 20 seconds.
- The cache can be disabled by passing `sentMessagesCache: undefined` in the socet config.
- Allows resend retry to work without any store or user configuration.