### PR TITLE
Add requestPlaceholderOnRetry to message retry logic

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -56,6 +56,7 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
   fireInitQueries: true,
   auth: undefined as any,
   markOnlineOnConnect: true,
+  requestPlaceholderOnRetry: true,
   syncFullHistory: false,
   shouldSyncHistoryMessage: () => true,
   shouldIgnoreJid: () => false,

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -169,7 +169,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
       signedIdentityKey: identityKey
     } = authState.creds;
 
-    if (requestPlaceholderOnRetry && retryCount === 4) {
+    if (requestPlaceholderOnRetry && retryCount === 1) {
       setTimeout(async () => {
         const msgId = await requestPlaceholderResend(msgKey);
         logger.debug(

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -57,7 +57,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
     retryRequestDelayMs,
     getMessage,
     sentMessagesCache,
-    shouldIgnoreJid
+    shouldIgnoreJid,
+    requestPlaceholderOnRetry
   } = config;
   const sock = makeMessagesSocket(config);
   const {
@@ -146,25 +147,36 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
   const sendRetryRequest = async (
     node: BinaryNode,
-    forceIncludeKeys = false
+    forceIncludeKeys = false,
+    msgKey: WAMessageKey
   ) => {
     const msgId = node.attrs.id;
+    const key = `${msgId}:${msgKey?.participant}`;
 
-    let retryCount = msgRetryMap[msgId] || 0;
+    let retryCount = msgRetryMap[key] || 0;
     if (retryCount >= 5) {
-      logger.error({ retryCount, msgId }, "reached retry limit, clearing");
-      delete msgRetryMap[msgId];
+      logger.error({ retryCount, key }, "reached retry limit, clearing");
+      delete msgRetryMap[key];
       return;
     }
 
     retryCount += 1;
-    msgRetryMap[msgId] = retryCount;
+    msgRetryMap[key] = retryCount;
 
     const {
       account,
       signedPreKey,
       signedIdentityKey: identityKey
     } = authState.creds;
+
+    if (requestPlaceholderOnRetry && retryCount === 4) {
+      setTimeout(async () => {
+        const msgId = await requestPlaceholderResend(msgKey);
+        logger.debug(
+          `sendRetryRequest: requested placeholder resend for message ${msgId} (scheduled)`
+        );
+      }, 3000);
+    }
 
     const deviceIdentity = encodeSignedDeviceIdentity(account!, true);
     await authState.keys.transaction(async () => {
@@ -768,7 +780,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
             retryMutex.mutex(async () => {
               if (ws.readyState === ws.OPEN) {
                 const encNode = getBinaryNodeChild(node, "enc");
-                await sendRetryRequest(node, !encNode);
+                await sendRetryRequest(node, !encNode, msg.key);
                 if (retryRequestDelayMs) {
                   await delay(retryRequestDelayMs);
                 }

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -57,6 +57,8 @@ export type SocketConfig = {
   groupMetadataCache?: NodeCache;
   /** provide a cache to store recently sent messages, used to resend the message when someone fails to decrypt it (waiting for this message problem). Default cache store message per 20 seconds. Pass undefined to disable*/
   sentMessagesCache?: NodeCache;
+  /** whether to request a placeholder message when retrying a failed message */
+  requestPlaceholderOnRetry?: boolean;
   /** marks the client as online whenever the socket successfully connects */
   markOnlineOnConnect: boolean;
   /**


### PR DESCRIPTION
Introduces the requestPlaceholderOnRetry option to SocketConfig and integrates it into the message retry mechanism. When enabled, a placeholder resend is requested on the fourth retry attempt for a failed message.