### PR TITLE
fix: revert to JID sessions

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -310,7 +310,8 @@ export const extractGroupMetadata = (result: BinaryNode) => {
     participants: getBinaryNodeChildren(group, "participant").map(
       ({ attrs }) => {
         return {
-          id: attrs.jid,
+          id: attrs.phone_number || attrs.jid,
+          lid: attrs.phone_number ? attrs.jid : undefined,
           admin: attrs.type || (null as any)
         };
       }

--- a/src/Utils/signal.ts
+++ b/src/Utils/signal.ts
@@ -317,8 +317,6 @@ export const extractDeviceJids = (
       for (const item of list) {
         const { user } = jidDecode(item.attrs.jid)!;
         const devicesNode = getBinaryNodeChild(item, "devices");
-        const lidNode = getBinaryNodeChild(item, "lid");
-        const lid = jidDecode(lidNode?.attrs?.val)?.user;
         const deviceListNode = getBinaryNodeChild(devicesNode, "device-list");
         if (Array.isArray(deviceListNode?.content)) {
           for (const { tag, attrs } of deviceListNode!.content) {
@@ -330,9 +328,9 @@ export const extractDeviceJids = (
               (device === 0 || !!attrs["key-index"]) // ensure that "key-index" is specified for "non-zero" devices, produces a bad req otherwise
             ) {
               extracted.push({
-                user: lid || user,
+                user: user,
                 device,
-                isLid: Boolean(lid || item.attrs?.jid?.endsWith("@lid"))
+                isLid: Boolean(item.attrs?.jid?.endsWith("@lid"))
               });
             }
           }


### PR DESCRIPTION
Por que? 

A implementação anterior (https://github.com/canove/whaileys/pull/35) contava com o LID vindo na resposta da interactive query que fazemos sempre que vamos enviar uma mensagem, na função `getUSyncDevices`.

Acontece que em algumas conexões, por um motivo desconhecido, essa query não retorna o LID. O mesmo acontece na função `onWhatsApp`, que supostamente deveria sempre retornar se o número é válido e também o LID associado ao número. 

Em resumo: em algumas conexões, **não é possível obter o LID a partir do JID**. 

Sendo assim, optei por voltar a implementação anterior, baseada em JID, sempre que ele estiver disponível. Quando não estiver, a LIB vai usar o LID para criar a sessão e também deve funcionar normalmente.

O problema que inicialmente motivou a migração para FULL LID segue resolvido, memso com essa alteração para JID

Para testar:

- Envie e receba mensagens em grupo para criar sessão com todos os participantes.
- Envie e receba mensagens para um participante do grupo no privado.
- Ao mudar do grupo para o privado, a mesma sessão deve ser usada, e nenhum `aguardando mensagem` deve ocorrer depois que a sessão for estabelecida. 


____
Why?

The previous implementation (https://github.com/canove/whaileys/pull/35) relied on the LID being returned in the response of the interactive query we perform whenever we send a message, in the `getUSyncDevices` function.

However, in some connections, for an unknown reason, this query does not return the LID. The same happens in the `onWhatsApp` function, which should supposedly always return whether the number is valid and also the LID associated with the number.

In short: in some connections, **it is not possible to obtain the LID from the JID**.

Therefore, I opted to revert to the previous implementation, based on JID, whenever it is available. When it is not available, the LIB will use the LID to create the session and should also work normally.

The problem that motivated the migration to FULL LID is now resolved. To test:

- Send and receive group messages to create a session with all participants.

- Send and receive messages to a group participant privately.

- When switching from group to private, the same session must be used, and no "waiting for message" should occur after the session is established.