### PR TITLE
fix(chats): update abprops query to fix bad-request error

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -773,21 +773,23 @@ export const makeChatsSocket = (config: SocketConfig) => {
     }
   };
 
-  /** sending non-abt props may fix QR scan fail if server expects */
+  /** fetch AB props */
   const fetchProps = async () => {
     const resultNode = await query({
       tag: "iq",
       attrs: {
         to: S_WHATSAPP_NET,
-        xmlns: "w",
+        xmlns: "abt",
         type: "get"
       },
       content: [
         {
           tag: "props",
           attrs: {
-            protocol: "2",
-            hash: authState?.creds?.lastPropHash || ""
+            protocol: "1",
+            ...(authState?.creds?.lastPropHash
+              ? { hash: authState.creds.lastPropHash }
+              : {})
           }
         }
       ]


### PR DESCRIPTION
A query antiga estava legada a muito tempo, mas o whatsapp ainda mantinha suporte, mas agora removeu a query completamente, causando bas-request a cada start de uma sessão já logada.

Como reproduzir o erro: Apenas iniciar uma sessão já logada, vai emitir bad-request