### PR TITLE
fix(message): add peer_recipient_pn on LID-addressed 1:1 sends

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -591,7 +591,13 @@ export const makeMessagesSocket = (config: SocketConfig) => {
             devices.length &&
             devices.find(d => d.user === destinationUser)?.lid;
 
-          if (destinationLid) destinationJid = jidEncode(destinationLid, "lid");
+          if (destinationLid) {
+            destinationJid = jidEncode(destinationLid, "lid");
+            additionalAttributes = {
+              ...additionalAttributes,
+              peer_recipient_pn: jidNormalizedUser(jid)
+            };
+          }
         }
 
         const encodedMeMsg = encodeWAMessage({


### PR DESCRIPTION
Corrige o problema "Usuário desconhecido" se o input for um PN