### PR TITLE
(fix) decryptSecretEncryptedMessage - MESSAGE_EDIT

### DIFF
--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -101,6 +101,25 @@ export const decryptSecretEncryptedMessage = async (
   meLid: string | undefined,
   logger?: Logger
 ) => {
+  // PATCH: Revive messageSecret if it was corrupted by JSON stringification in the DB
+  if (
+    messageSecret &&
+    !Buffer.isBuffer(messageSecret) &&
+    !(messageSecret instanceof Uint8Array)
+  ) {
+    if (typeof messageSecret === "string") {
+      messageSecret = Buffer.from(messageSecret, "base64");
+    } else if (typeof messageSecret === "object") {
+      const obj: any = messageSecret;
+      const keys = Object.keys(obj).filter(k => !isNaN(Number(k)));
+      if (keys.length > 0) {
+        const arr = new Uint8Array(keys.length);
+        for (let i = 0; i < keys.length; i++) arr[i] = obj[String(i)];
+        messageSecret = arr;
+      }
+    }
+  }
+
   const content = normalizeMessageContent(message.message);
   const secretEncryptedMessage = content?.secretEncryptedMessage;
   if (!secretEncryptedMessage) return;


### PR DESCRIPTION
Resolve um problema em que a Whaileys não estava descriptografando mensagens editadas automaticamente vindas direto do celular de um contato, mas quando o envio era feito pelo WhatsApp Web, a edição era aceita normalmente. Esta correção resolve essa inconsistência.

- Evita falhas críticas de `RangeError: index out of range` geradas pelo `protobufjs` durante a descriptografia de eventos MESSAGE_EDIT oriundos de instâncias Multi-Device externas, mantendo a estabilidade da biblioteca.

- Adiciona suporte no processo `decryptSecretEncryptedMessage` (em Utils/process-message) para reviver o buffer `messageSecret` automaticamente caso ele venha corrompido ou convertido por ORMs e persistências externas.

- Processa adequadamente strings em Base64 ou falsos objetos do tipo Uint8Array (ex: `{"0": 1, "1": 255...}`), reconvertendo-os para buffers reais antes de calcular as assinaturas HKDF e AES-GCM.

Resolve: https://github.com/WhiskeySockets/Baileys/pull/2547